### PR TITLE
Changed white space descriptor as was causing double spaces

### DIFF
--- a/Clean.Site/Views/Partials/pageHeader.cshtml
+++ b/Clean.Site/Views/Partials/pageHeader.cshtml
@@ -21,9 +21,7 @@
                             Posted
                             @if (Model.HasAuthor)
                             {
-                                @Umbraco.GetDictionaryValue("Article.By")
-
-                                @Html.Raw("&nbsp;")@Model.AuthorName
+                                @Umbraco.GetDictionaryValue("Article.By")@Html.Raw("&nbsp;")@Model.AuthorName
                             }
                             @Umbraco.GetDictionaryValue("Article.On")@Html.Raw("&nbsp;")@Model.ArticleDate.Value.ToString("MMMM dd, yyyy")
                         </span>

--- a/Clean.Site/Views/Partials/pageHeader.cshtml
+++ b/Clean.Site/Views/Partials/pageHeader.cshtml
@@ -23,7 +23,7 @@
                             {
                                 @Umbraco.GetDictionaryValue("Article.By")
 
-                                @:&nbsp;@Model.AuthorName
+                                @Html.Raw("&nbsp;")@Model.AuthorName
                             }
                             @Umbraco.GetDictionaryValue("Article.On")@Html.Raw("&nbsp;")@Model.ArticleDate.Value.ToString("MMMM dd, yyyy")
                         </span>


### PR DESCRIPTION
White space using `@:&nbsp;` created two spaces:
"Posted by  Paul Seal"

White space using @Html.Raw("&nbsp;") creates one space:
"Posted by Paul Seal"

Tada 🪄